### PR TITLE
Fixes to remediate VM hangs due to finalizer state mishandling

### DIFF
--- a/pkg/watcher/handler/pod.go
+++ b/pkg/watcher/handler/pod.go
@@ -45,6 +45,13 @@ func (p *podEventHandler) OnAdd(obj interface{}, _ bool) {
 	}
 	log.Info().Msgf("pod add Event: namespace %s name %s", pod.Namespace, pod.Name)
 
+	// Check if pod is already in terminating state (DeletionTimestamp is set)
+	if pod.DeletionTimestamp != nil {
+		log.Info().Msgf("pod is already in terminating state: namespace %s name %s", pod.Namespace, pod.Name)
+		p.handleTerminatingPod(pod)
+		return
+	}
+
 	if !utils.PodWantsNetwork(pod) {
 		log.Debug().Msg("pod doesn't require network")
 		return


### PR DESCRIPTION
Part of: https://linear.app/together-ai/issue/TCL-1982/fix-ib-kubernetes-guid-assignment-flow-and-pkey-creation

Quick fixes to remediate finalizers not being cleaned up and VMs hanging.

Fixes:
- Move backoff logic to only daemon.go instead of in daemon.go and client.go to reduce backoff time (this was causing ib-kubernetes to freeze).  Additionally, don't retry on pod not found in deleteFinalizer (we expect the pod to not exist after the first network is handled for a pod since it will remove the finalizer.  Subsequent networks will also attempt to remove the finalizer, but kept stalling in retry loops even though we expect a not found).
- Don't panic on cache.DeletedFinalStateUnknown objects in the OnDelete() handler.  These are expected if the eventHandler lags, and OnDelete() isn't used for cleanup anymore since the finalizer already needs to be cleaned up for the event to be fired. handleTerminatingPod from OnUpdate() handles cleanup, OnDelete() is a noop
- Check and handle pods with deletion timestamp already set.  When ib-kubernetes restarts, it sees all existing pods as OnAdd() events with all changes squashed, so pods in terminating state when ib-kuberentes spins up never saw a subsequent OnUpdate() event that triggered cleanup.  This will remedy that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle terminating pods immediately, centralize backoff in daemon with NotFound tolerance, safely manage NAD finalizers, and harden pod event handling with new tests.
> 
> - **Daemon (`pkg/daemon/daemon.go`)**:
>   - Centralizes retry/backoff for pod finalizer ops; tolerates `NotFound` on `removePodFinalizer` (expected for already-deleted pods).
>   - On delete flow, logs and skips when pod finalizer removal hits `NotFound`.
>   - Adds `removeNADFinalizerIfSafe` with `checkIfAnyPodsUsingNetwork` to conditionally remove NAD finalizers after cleanup.
>   - Minor logging and control-flow tweaks in add/delete periodic updates.
> - **K8s Client (`pkg/k8s-client/client.go`)**:
>   - Removes exponential backoff and related imports; `Add/RemoveFinalizerFromPod` now perform single `Update` calls.
> - **Watcher/Handler (`pkg/watcher/handler/pod.go`)**:
>   - Adds safe type assertions in `OnAdd/OnUpdate/OnDelete` to avoid panics (e.g., `DeletedFinalStateUnknown`).
>   - Detects and processes terminating pods via `DeletionTimestamp` in `OnAdd` and `OnUpdate`; tracks in `terminatingPods` and enqueues for deletion handling.
>   - Cleans retry/terminating maps on delete.
> - **Tests (`pkg/watcher/handler/pod_test.go`)**:
>   - Adds coverage for terminating pod handling on add/update and for delete with `DeletedFinalStateUnknown`.
>   - Updates invalid-case scenarios accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b62f27a8da72b98e613359368757d7b875a3ad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->