### PR TITLE
Make OnDelete a noop

### DIFF
--- a/pkg/watcher/handler/pod_test.go
+++ b/pkg/watcher/handler/pod_test.go
@@ -196,9 +196,10 @@ var _ = Describe("Pod Event Handler", func() {
 			podEventHandler.OnDelete(pod2)
 
 			_, delMap := podEventHandler.GetResults()
-			Expect(len(delMap.Items)).To(Equal(1))
-			Expect(len(delMap.Items["default_test"].([]*kapi.Pod))).To(Equal(2))
+			// OnDelete should be a noop now.
+			Expect(len(delMap.Items)).To(Equal(0))
 		})
+		// Still worth testing to make sure it won't panic.
 		It("On delete pod invalid cases", func() {
 			// No network needed
 			pod1 := &kapi.Pod{Spec: kapi.PodSpec{HostNetwork: true}}


### PR DESCRIPTION
The finalizer indicates if a pod has GUIDs that need cleanup, so once OnDelete is called, no more GUIDs should exist, so it is not necessary.

Prevents the race where if a GUID gets re-assigned quickly between setting the deletion timestamp and OnDelete, ib-kubernetes could remove the GUID which was re-assigned from the storage pkey.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make OnDelete a no-op, shifting cleanup to a new terminating-pod path triggered when DeletionTimestamp is set, with tests updated accordingly.
> 
> - **Watcher: `pkg/watcher/handler/pod.go`**
>   - **OnDelete**: Remove network-annotation parsing and `deletedPods` updates; now only cleans tracking maps (`retryPods`, `terminatingPods`).
>   - **Terminating flow**: Introduce `terminatingPods` tracking and `handleTerminatingPod` invoked when a pod is already terminating on `OnAdd` or transitions on `OnUpdate`.
>     - Parses networks and updates `deletedPods` for InfiniBand networks with GUIDs.
>     - Prevents duplicate handling and removes from `retryPods`.
> - **Tests: `pkg/watcher/handler/pod_test.go`**
>   - Update expectations: `OnDelete` is a no-op (no `deletedPods` entries).
>   - Add/adjust tests for terminating path on `OnAdd`/`OnUpdate` and invalid cases (no panics, no entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a55ff51995e592f641729e03a57c5337ab722f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->