### PR TITLE
[TCL-4147] fix: add SM_TIMEZONE to handle UFM local-time timestamps

### DIFF
--- a/deployment/ib-kubernetes-configmap.yaml
+++ b/deployment/ib-kubernetes-configmap.yaml
@@ -11,3 +11,4 @@ data:
   # DEFAULT_LIMITED_PARTITION: "0x0001" # optional
   ENABLE_IP_OVER_IB: "false" # default false
   ENABLE_INDEX0_FOR_PRIMARY_PKEY: "true" # default true
+  # SM_TIMEZONE: "UTC" # optional; IANA timezone of the UFM server (e.g. "America/New_York"). Default: "UTC"

--- a/deployment/ib-kubernetes.yaml
+++ b/deployment/ib-kubernetes.yaml
@@ -169,3 +169,9 @@ spec:
                   key: ENABLE_INDEX0_FOR_PRIMARY_PKEY
                   name: ib-kubernetes-config
                   optional: true
+            - name: SM_TIMEZONE
+              valueFrom:
+                configMapKeyRef:
+                  key: SM_TIMEZONE
+                  name: ib-kubernetes-config
+                  optional: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,12 +63,8 @@ func (dc *DaemonConfig) ReadConfig() error {
 		log.Info().Msg("Default limited partition is not set.")
 	}
 
-	// If SM timezone is set - log at startup
-	if dc.SMTimezone != "" {
-		log.Info().Msgf("SM timezone is set to %s.", dc.SMTimezone)
-	} else {
-		log.Info().Msg("SM timezone is not set.")
-	}
+	// Log at startup
+	log.Info().Msgf("SM timezone is set to %s.", dc.SMTimezone)
 
 	return err
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -95,5 +95,22 @@ var _ = Describe("Configuration", func() {
 			err := dc.ValidateConfig()
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("Validate configuration with valid SM_TIMEZONE", func() {
+			dc := &DaemonConfig{
+				PeriodicUpdate: 10,
+				Plugin:         "ufm",
+				SMTimezone:     "America/New_York"}
+			err := dc.ValidateConfig()
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Validate configuration with invalid SM_TIMEZONE", func() {
+			dc := &DaemonConfig{
+				PeriodicUpdate: 10,
+				Plugin:         "ufm",
+				SMTimezone:     "Fake/Timezone"}
+			err := dc.ValidateConfig()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid SM_TIMEZONE"))
+		})
 	})
 })

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -185,6 +185,7 @@ func NewDaemon() (Daemon, error) {
 		"ENABLE_IP_OVER_IB":              daemonConfig.EnableIPOverIB,
 		"DEFAULT_LIMITED_PARTITION":      daemonConfig.DefaultLimitedPartition,
 		"ENABLE_INDEX0_FOR_PRIMARY_PKEY": daemonConfig.EnableIndex0ForPrimaryPkey,
+		"SM_TIMEZONE":                    daemonConfig.SMTimezone,
 	}
 	if err := smClient.SetConfig(pluginConfig); err != nil {
 		log.Warn().Msgf("Failed to set configuration on subnet manager plugin: %v", err)

--- a/pkg/sm/plugins/ufm/ufm.go
+++ b/pkg/sm/plugins/ufm/ufm.go
@@ -41,7 +41,7 @@ type UFMConfig struct {
 	EnableIPOverIB             bool   `env:"ENABLE_IP_OVER_IB"              envDefault:"false"`
 	DefaultLimitedPartition    string `env:"DEFAULT_LIMITED_PARTITION"`
 	EnableIndex0ForPrimaryPkey bool   `env:"ENABLE_INDEX0_FOR_PRIMARY_PKEY" envDefault:"true"`
-	SMTimezone                 string `env:"SM_TIMEZONE"`
+	SMTimezone                 string `env:"SM_TIMEZONE"                    envDefault:"UTC"`
 }
 
 func newUfmPlugin() (*ufmPlugin, error) {

--- a/pkg/sm/plugins/ufm/ufm.go
+++ b/pkg/sm/plugins/ufm/ufm.go
@@ -21,6 +21,7 @@ type ufmPlugin struct {
 	SpecVersion string
 	conf        UFMConfig
 	client      httpDriver.Client
+	smLocation  *time.Location // cached SM server timezone for timestamp parsing
 }
 
 const (
@@ -40,6 +41,7 @@ type UFMConfig struct {
 	EnableIPOverIB             bool   `env:"ENABLE_IP_OVER_IB"              envDefault:"false"`
 	DefaultLimitedPartition    string `env:"DEFAULT_LIMITED_PARTITION"`
 	EnableIndex0ForPrimaryPkey bool   `env:"ENABLE_INDEX0_FOR_PRIMARY_PKEY" envDefault:"true"`
+	SMTimezone                 string `env:"SM_TIMEZONE"`
 }
 
 func newUfmPlugin() (*ufmPlugin, error) {
@@ -311,6 +313,18 @@ func (u *ufmPlugin) SetConfig(config map[string]interface{}) error {
 		}
 	}
 
+	if smTimezone, exists := config["SM_TIMEZONE"]; exists {
+		if strVal, ok := smTimezone.(string); ok {
+			u.conf.SMTimezone = strVal
+			loc, err := time.LoadLocation(strVal)
+			if err != nil {
+				return fmt.Errorf("invalid SM_TIMEZONE %q: %v", strVal, err)
+			}
+			u.smLocation = loc
+			log.Info().Msgf("UFM plugin: SMTimezone set to %s via SetConfig", strVal)
+		}
+	}
+
 	return nil
 }
 
@@ -337,17 +351,32 @@ func (u *ufmPlugin) GetLastPKeyUpdateTimestamp() (time.Time, error) {
 		return time.Time{}, nil
 	}
 
-	// Try multiple timestamp formats that UFM might return
-	timestampFormats := []string{
-		"02-01-2006, 15:04:05",         // DD-MM-YYYY, HH:MM:SS (newer UFM format)
+	// Try multiple timestamp formats that UFM might return.
+	// Prefer formats with timezone info first so we use UFM's explicit TZ when present.
+	// Fall back to formats without TZ, parsed in SM's local timezone (SMTimezone).
+	tzFormats := []string{
 		"Mon Jan  2 15:04:05 MST 2006", // Thu Sep  3 11:42:39 UTC 2020 (double space for single-digit day)
 		"Mon Jan 2 15:04:05 MST 2006",  // Thu Sep 13 11:42:39 UTC 2020 (single space for double-digit day)
 	}
-
-	for _, format := range timestampFormats {
+	for _, format := range tzFormats {
 		lastUpdated, err := time.Parse(format, *lastUpdatedResp.LastUpdated)
 		if err == nil {
 			return lastUpdated, nil
+		}
+	}
+
+	smLocation := u.smLocation
+	if smLocation == nil {
+		smLocation = time.UTC
+	}
+
+	localFormats := []string{
+		"02-01-2006, 15:04:05", // DD-MM-YYYY, HH:MM:SS (newer UFM format)
+	}
+	for _, format := range localFormats {
+		lastUpdated, err := time.ParseInLocation(format, *lastUpdatedResp.LastUpdated, smLocation)
+		if err == nil {
+			return lastUpdated.UTC(), nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

- UFM's `/ufmRest/resources/pkeys/last_updated` returns timestamps in server-local time without timezone info, but `GetServerTime()` returns UTC via the HTTP `Date` header. For servers west of UTC (e.g. EST in APLD3), this creates a permanent mismatch that blocks all PKey add/remove operations via `canProceedWithPkeyModification()`.
- Adds a configurable `SM_TIMEZONE` (IANA timezone name, e.g. `America/New_York`) so local-time timestamps are correctly converted to UTC before comparison. Uses `time.LoadLocation` for automatic DST handling.
- Validated at startup (fail-fast on invalid timezone), cached once in `SetConfig()` (not re-loaded every cycle), defaults to UTC (no behavior change if unset).

## Changes

| File | Change |
|------|--------|
| `pkg/config/config.go` | Add `SMTimezone` field with env tag, startup validation via `time.LoadLocation` |
| `pkg/daemon/daemon.go` | Pass `SM_TIMEZONE` to plugin via `SetConfig` |
| `pkg/sm/plugins/ufm/ufm.go` | Cache `*time.Location`, use `ParseInLocation` for local-time formats, try tz-aware formats first |
| `pkg/config/config_test.go` | Tests for valid/invalid `SM_TIMEZONE` validation |
| `pkg/sm/plugins/ufm/ufm_test.go` | Tests for timezone conversion, DST handling (EDT), nil fallback, SetConfig valid/invalid |
| `deployment/` | Add `SM_TIMEZONE` to configmap and deployment yaml |

## Configuration

Add to the ib-kubernetes configmap:
```yaml
SM_TIMEZONE: "America/New_York"  # IANA timezone of the UFM server
```

## Test plan

- [x] All 48 unit tests pass (10 config + 38 UFM plugin)
- [x] Build succeeds (daemon binary + UFM plugin .so)
- [x] Deploy to APLD3 substrate with `SM_TIMEZONE: "America/New_York"` and verify PKey operations unblock
  - Verified the effectiveness of the solution with/without the configmap update.
  - Verified add/delete VMs got completely unblocked with `SM_TIMEZONE: "America/New_York"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)