### PR TITLE
Fix golangci-lint errors across codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test: | plugins; $(info  running $(NAME:%=% )tests...) @ ## Run tests
 	$Q $(GO) test $(GOFLAGS) -timeout $(TIMEOUT)s $(ARGS) ./...
 
 .PHONY: test-coverage
-test-coverage: | plugins-coverage envtest gocovmerge gcov2lcov ## Run coverage tests
+test-coverage: | plugins-coverage envtest ## Run coverage tests
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR) -p path)" go test -cover -covermode=$(COVER_MODE) -coverprofile=$(COVER_PROFILE) $(PKGS)
 
 # Container image

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,7 +50,9 @@ func (dc *DaemonConfig) ReadConfig() error {
 
 	// If default limited partition is set - log at startup
 	if dc.DefaultLimitedPartition != "" {
-		log.Info().Msgf("Default limited partition is set to %s. New GUIDs will be added as limited members to this partition.", dc.DefaultLimitedPartition)
+		log.Info().Msgf("Default limited partition is set to %s."+
+			" New GUIDs will be added as limited members to this partition.",
+			dc.DefaultLimitedPartition)
 	} else {
 		log.Info().Msg("Default limited partition is not set.")
 	}

--- a/pkg/guid/guid_pool.go
+++ b/pkg/guid/guid_pool.go
@@ -75,18 +75,18 @@ func (p *guidPool) Reset(guids []string) error {
 			// Out of range GUID may be expected and shouldn't be allocated in the pool
 			continue
 		}
-		
+
 		guidAddr, err := ParseGUID(guid)
 		if err != nil {
 			log.Debug().Msgf("error parsing GUID: %s: %v", guid, err)
 			return err
 		}
-		
+
 		// Check if GUID is already allocated in the pool, if so skip it
 		if _, exist := p.guidPoolMap[guidAddr]; exist {
 			continue
 		}
-		
+
 		err = p.AllocateGUID(guid)
 		if err != nil {
 			log.Debug().Msgf("error resetting the pool with value: %s: %v", guid, err)

--- a/pkg/k8s-client/client.go
+++ b/pkg/k8s-client/client.go
@@ -17,7 +17,9 @@ import (
 )
 
 type Client interface {
-	GetPods(namespace string) (*kapi.PodList, error) // NOTE: List pods need strong consistency guarantees, ListOptions cannot be modified to use non-quorum reads.
+	// NOTE: List pods need strong consistency guarantees,
+	// ListOptions cannot be modified to use non-quorum reads.
+	GetPods(namespace string) (*kapi.PodList, error)
 	SetAnnotationsOnPod(pod *kapi.Pod, annotations map[string]string) error
 	PatchPod(pod *kapi.Pod, patchType types.PatchType, patchData []byte) error
 	GetNetworkAttachmentDefinition(namespace, name string) (*netapi.NetworkAttachmentDefinition, error)

--- a/pkg/sm/plugins/ufm/ufm.go
+++ b/pkg/sm/plugins/ufm/ufm.go
@@ -27,18 +27,19 @@ const (
 	pluginName  = "ufm"
 	specVersion = "1.0"
 	httpsProto  = "https"
+	trueStr     = "true"
 )
 
 type UFMConfig struct {
-	Username                   string `env:"UFM_USERNAME"`                                     // Username of ufm
-	Password                   string `env:"UFM_PASSWORD"`                                     // Password of ufm
-	Address                    string `env:"UFM_ADDRESS"`                                      // IP address or hostname of ufm server
-	Port                       int    `env:"UFM_PORT"`                                         // REST API port of ufm
-	HTTPSchema                 string `env:"UFM_HTTP_SCHEMA"`                                  // http or https
-	Certificate                string `env:"UFM_CERTIFICATE"`                                  // Certificate of ufm
-	EnableIPOverIB             bool   `env:"ENABLE_IP_OVER_IB" envDefault:"false"`             // Enable IP over IB functionality
-	DefaultLimitedPartition    string `env:"DEFAULT_LIMITED_PARTITION"`                        // Default partition key for limited membership
-	EnableIndex0ForPrimaryPkey bool   `env:"ENABLE_INDEX0_FOR_PRIMARY_PKEY" envDefault:"true"` // Enable index0 for primary pkey GUID additions
+	Username                   string `env:"UFM_USERNAME"`
+	Password                   string `env:"UFM_PASSWORD"`
+	Address                    string `env:"UFM_ADDRESS"`
+	Port                       int    `env:"UFM_PORT"`
+	HTTPSchema                 string `env:"UFM_HTTP_SCHEMA"`
+	Certificate                string `env:"UFM_CERTIFICATE"`
+	EnableIPOverIB             bool   `env:"ENABLE_IP_OVER_IB"              envDefault:"false"`
+	DefaultLimitedPartition    string `env:"DEFAULT_LIMITED_PARTITION"`
+	EnableIndex0ForPrimaryPkey bool   `env:"ENABLE_INDEX0_FOR_PRIMARY_PKEY" envDefault:"true"`
 }
 
 func newUfmPlugin() (*ufmPlugin, error) {
@@ -48,9 +49,11 @@ func newUfmPlugin() (*ufmPlugin, error) {
 	}
 
 	// Debug logging for environment variable parsing
-	log.Info().Msgf("UFM plugin: Environment variable ENABLE_IP_OVER_IB parsed as: %t", ufmConf.EnableIPOverIB)
-	log.Info().Msgf("UFM plugin: Environment variable DEFAULT_LIMITED_PARTITION parsed as: '%s'", ufmConf.DefaultLimitedPartition)
-	log.Info().Msgf("UFM plugin: Environment variable ENABLE_INDEX0_FOR_PRIMARY_PKEY parsed as: %t", ufmConf.EnableIndex0ForPrimaryPkey)
+	log.Info().Msgf("UFM plugin: ENABLE_IP_OVER_IB=%t", ufmConf.EnableIPOverIB)
+	log.Info().Msgf("UFM plugin: DEFAULT_LIMITED_PARTITION='%s'",
+		ufmConf.DefaultLimitedPartition)
+	log.Info().Msgf("UFM plugin: ENABLE_INDEX0_FOR_PRIMARY_PKEY=%t",
+		ufmConf.EnableIndex0ForPrimaryPkey)
 
 	if ufmConf.Username == "" || ufmConf.Password == "" || ufmConf.Address == "" {
 		return nil, fmt.Errorf("missing one or more required fileds for ufm [\"username\", \"password\", \"address\"]")
@@ -284,7 +287,7 @@ func (u *ufmPlugin) SetConfig(config map[string]interface{}) error {
 			log.Info().Msgf("UFM plugin: EnableIPOverIB set to %t via SetConfig", boolVal)
 		} else if strVal, ok := enableIPOverIB.(string); ok {
 			// Handle string values like "true", "false"
-			u.conf.EnableIPOverIB = strVal == "true"
+			u.conf.EnableIPOverIB = strVal == trueStr
 			log.Info().Msgf("UFM plugin: EnableIPOverIB set to %t via SetConfig (from string %s)", u.conf.EnableIPOverIB, strVal)
 		}
 	}
@@ -302,8 +305,9 @@ func (u *ufmPlugin) SetConfig(config map[string]interface{}) error {
 			log.Info().Msgf("UFM plugin: EnableIndex0ForPrimaryPkey set to %t via SetConfig", boolVal)
 		} else if strVal, ok := enableIndex0ForPrimaryPkey.(string); ok {
 			// Handle string values like "true", "false"
-			u.conf.EnableIndex0ForPrimaryPkey = strVal == "true"
-			log.Info().Msgf("UFM plugin: EnableIndex0ForPrimaryPkey set to %t via SetConfig (from string %s)", u.conf.EnableIndex0ForPrimaryPkey, strVal)
+			u.conf.EnableIndex0ForPrimaryPkey = strVal == trueStr
+			log.Info().Msgf("UFM plugin: EnableIndex0ForPrimaryPkey set to %t via SetConfig (from string %s)",
+				u.conf.EnableIndex0ForPrimaryPkey, strVal)
 		}
 	}
 
@@ -347,7 +351,9 @@ func (u *ufmPlugin) GetLastPKeyUpdateTimestamp() (time.Time, error) {
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("failed to parse last_updated timestamp %q: no matching format found", *lastUpdatedResp.LastUpdated)
+	return time.Time{}, fmt.Errorf(
+		"failed to parse last_updated timestamp %q: no matching format found",
+		*lastUpdatedResp.LastUpdated)
 }
 
 // GetServerTime returns the current time on the UFM server.

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -10,9 +10,7 @@ import (
 	resEventHandler "github.com/Mellanox/ib-kubernetes/pkg/watcher/handler"
 )
 
-var (
-	kubevirtSelectorString = SelectorMustValidateFromSet(labels.Set{"kubevirt.io": "virt-launcher"}).String()
-)
+var kubevirtSelectorString = SelectorMustValidateFromSet(labels.Set{"kubevirt.io": "virt-launcher"}).String()
 
 type StopFunc func()
 
@@ -31,10 +29,10 @@ type watcher struct {
 func NewWatcher(eventHandler resEventHandler.ResourceEventHandler, client k8sClient.Client) Watcher {
 	resource := eventHandler.GetResourceObject().GetObjectKind().GroupVersionKind().Kind
 	filterByKubevirtLabel := func(options *metav1.ListOptions) {
-
 		options.LabelSelector = kubevirtSelectorString
 	}
-	watchList := cache.NewFilteredListWatchFromClient(client.GetRestClient(), resource, kapi.NamespaceAll, filterByKubevirtLabel)
+	watchList := cache.NewFilteredListWatchFromClient(
+		client.GetRestClient(), resource, kapi.NamespaceAll, filterByKubevirtLabel)
 	return &watcher{eventHandler: eventHandler, watchList: watchList}
 }
 
@@ -58,7 +56,8 @@ func (w *watcher) GetHandler() resEventHandler.ResourceEventHandler {
 	return w.eventHandler
 }
 
-// SelectorMustValidateFromSet acts like regex.MustCompile for labels.Selector objects.  It will attempt to validate the selector from the label set and panic if it fails.
+// SelectorMustValidateFromSet acts like regex.MustCompile for labels.Selector objects.
+// It will attempt to validate the selector from the label set and panic if it fails.
 func SelectorMustValidateFromSet(set labels.Set) labels.Selector {
 	selector, err := labels.ValidatedSelectorFromSet(set)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix all golangci-lint violations across 6 files: `daemon.go`, `ufm.go`, `config.go`, `watcher.go`, `guid_pool.go`, `client.go`
- Linter rules fixed: lll (line length >120), gofumpt (const grouping), gofmt (whitespace), goconst (repeated strings), gocritic (if-else chain → switch), stylecheck (pkeyToNetworkId → pkeyToNetworkID), nolintlint (unused //nolint directives), whitespace (leading newlines), funlen (suppressed with //nolint:funlen), tagalign (struct tag alignment)
- Fix CI `make test-coverage` failure: remove unused `gocovmerge` and `gcov2lcov` prerequisites from the `test-coverage` Makefile target (neither tool is used in the recipe, and `gocovmerge` fails to install because its transitive dep `golang.org/x/tools` requires Go 1.24+ while CI runs Go 1.22)
- No behavioral changes

## Test plan
- [x] All existing tests pass (`go test ./pkg/...`)
- [x] All changed packages compile successfully
- [x] CI golangci-lint passes
- [x] CI `make test-coverage` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)