### PR TITLE
Fix gocovmerge install failing due to Go version mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,6 @@ define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(BIN_DIR) go install $(2) ;\
+GOBIN=$(BIN_DIR) GOTOOLCHAIN=auto go install $(2) ;\
 }
 endef


### PR DESCRIPTION
## Summary
- Add `GOTOOLCHAIN=auto` to the `go-install-tool` Makefile macro
- This allows `go install` to auto-download a newer Go toolchain when a dependency requires it
- Fixes `gocovmerge` install which transitively pulls `golang.org/x/tools@v0.42.0` (requires Go 1.24+) while CI runs Go 1.22

## Test plan
- [ ] CI `make test-coverage` passes without `go: golang.org/x/tools@v0.42.0 requires go >= 1.24.0` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)