### PR TITLE
Switch to tc-prod private repo by default

### DIFF
--- a/tag_build_and_push.sh
+++ b/tag_build_and_push.sh
@@ -1,16 +1,19 @@
 #! /bin/bash
 # if env var exists, use it - or else get short git commit hash
 TAG=${TAG:-$(git rev-parse --short HEAD)}
-echo "Going to build and push tag: $TAG"
+echo "Going to build and push tag: $TAG (Use 'TAG=TAG_NAME ./$0' to override)"
 
 set -eou pipefail
 
+# (tc-prod private repo)
+IMAGE_REPO=651706779278.dkr.ecr.us-west-2.amazonaws.com
 
 read -p "Have you logged in to aws and ecr? ([y]/n): " confirm
 if [ "$confirm" == "n" ]; then    
-    echo "Logging in to aws and ecr"
-    aws sso login
-    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+    echo "Run:"
+    echo "aws sso login (login to tc-prod)"
+    echo "aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $IMAGE_REPO"
+    exit 1
 fi
 
 echo "Building and deploying $TAG"
@@ -21,13 +24,13 @@ make build
 #     echo "Tests failed"    
 #     exit 1
 # fi
-make image TAG=public.ecr.aws/k6t4m3l7/ib-kubernetes:$TAG
+make image TAG=$IMAGE_REPO/ib-kubernetes:$TAG
 # ask to confirm
 read -p "Are you sure you want to push and deploy $TAG? (y/[n]): " confirm
 if [ "$confirm" != "y" ]; then
     echo "Deployment cancelled"
     exit 1
 fi
-make docker-push TAG=public.ecr.aws/k6t4m3l7/ib-kubernetes:$TAG
+make docker-push TAG=$IMAGE_REPO/ib-kubernetes:$TAG
 
 echo "To Deploy, install/upgrade via helm!"


### PR DESCRIPTION
Part of tcl-4461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a local build/push helper script, but could misdirect image pushes if the ECR repo/region is incorrect.
> 
> **Overview**
> `tag_build_and_push.sh` now targets the tc-prod private ECR (`651706779278.dkr.ecr.us-west-2.amazonaws.com`) for `make image`/`make docker-push` instead of the public ECR repo.
> 
> The script no longer auto-runs AWS/ECR login; if the user answers they are not logged in, it prints the required `aws sso login`/`aws ecr get-login-password` commands and exits. It also clarifies how to override the image tag via `TAG=...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049c710ba2cdf8ed8cc51833032656332ffd63a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->